### PR TITLE
build: configure base path and simplify vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    { "src": "api/send.js", "use": "@vercel/node" },
-    { "src": "package.json", "use": "@vercel/static-build" }
-  ],
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1" },
     { "src": "/(.*)", "dest": "/index.html" }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,5 +5,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: "dist"
-  }
+  },
+  base: "./"  // 👈 ensures relative paths for assets
 });
+


### PR DESCRIPTION
Set base path to "./" in vite config for proper asset loading Remove redundant builds configuration from vercel.json